### PR TITLE
Enhance the "offer" button and backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,4 +154,7 @@ clean:
 	$(MAKE) -C third_party clean
 	git clean -f -d
 
-.PHONY : lint third_party upload deploy serve clean
+edit:
+	$(EDITOR) *.py templates/*.html static/css/*.css
+
+.PHONY : lint third_party upload deploy serve clean edit

--- a/event_lists.py
+++ b/event_lists.py
@@ -59,7 +59,6 @@ def get_future_events(
     return EventList(get_eventlist_responses(
         future_events, user), "Coming soon")
 
-
 def get_current_events(
         year=None, month=None, day=None, published_only=True, user=None,
         count=5):

--- a/handler-admin.py
+++ b/handler-admin.py
@@ -19,15 +19,12 @@ import aeoid.middleware
 # Import the actual handlers
 import event_edit
 import event_publish
-import offers
 
 application = webapp.WSGIApplication(
   [('/event/add', event_edit.EditEvent),
    ('/event/(.*)/edit', event_edit.EditEvent),
    ('/event/(.*)/publish', event_publish.PublishEvent),
    ('/event/(.*)/email', event_publish.SendEmailAboutEvent),
-   ('/offer/add', offers.EditOffer),
-   ('/offer/(.*)/edit', offers.EditOffer),
    ],
   debug=True)
 application = aeoid.middleware.AeoidMiddleware(application)

--- a/handler.py
+++ b/handler.py
@@ -20,7 +20,7 @@ import aeoid.middleware
 import index
 import response
 import events
-import offers
+import offer_edit
 import ical
 import rss
 
@@ -39,8 +39,8 @@ application = webapp.WSGIApplication(
    ('/events[/]?(?P<year>[^/]*)[/]?(?P<month>[^/]*)[/]?(?P<day>[^/]*)[/]?',
         events.Events),
    ('/event/(.*)', events.Event),
-   ('/offer/(.*)/edit', offers.EditOffer),
-   ('/offer/add', offers.EditOffer),
+   ('/offer/(.*)/edit', offer_edit.EditOffer),
+   ('/offer/add', offer_edit.EditOffer),
    ('/refresh', index.Refresh),
    ('/(.*)', index.StaticTemplate),
    ],

--- a/models.py
+++ b/models.py
@@ -67,6 +67,7 @@ class TalkOffer(db.Model):
             auto_now_add=True, required=True)
 
     name = db.StringProperty(required=True)
+    active = db.BooleanProperty(required=True,default=True)
     text = db.TextProperty()
     seconds = db.IntegerProperty()
     consent = db.BooleanProperty()

--- a/models.py
+++ b/models.py
@@ -69,6 +69,7 @@ class TalkOffer(db.Model):
     name = db.StringProperty(required=True)
     active = db.BooleanProperty(required=True,default=True)
     text = db.TextProperty()
+    displayname = db.StringProperty()
     seconds = db.IntegerProperty()
     consent = db.BooleanProperty()
 

--- a/offer_edit.py
+++ b/offer_edit.py
@@ -19,7 +19,7 @@ from utils.render import render as r
 
 
 class EditOffer(webapp.RequestHandler):
-    """Handler for creating and editing Event objects."""
+    """Handler for creating and editing Offer objects."""
 
     def get(self, key=None):
         if key:

--- a/offer_edit.py
+++ b/offer_edit.py
@@ -16,12 +16,17 @@ from google.appengine.ext import webapp
 # Our App imports
 import models
 from utils.render import render as r
+from aeoid import users as openid_users
 
 
 class EditOffer(webapp.RequestHandler):
     """Handler for creating and editing Offer objects."""
 
     def get(self, key=None):
+        user = openid_users.get_current_user()
+        if not user:
+          self.redirect(openid_users.create_login_url(self.request.url))
+          return
         if key:
             try:
                 key = long(key)
@@ -39,6 +44,11 @@ class EditOffer(webapp.RequestHandler):
             ))
 
     def post(self, key=None):
+        user = openid_users.get_current_user()
+        if not user:
+          self.redirect(openid_users.create_login_url(self.request.url))
+          return
+
         if key:
             try:
                 key = long(key)

--- a/offer_edit.py
+++ b/offer_edit.py
@@ -73,6 +73,7 @@ class EditOffer(webapp.RequestHandler):
         if not consent:
             consent = False
 
+        offer.displayname = self.request.get('displayname')
         offer.text = self.request.get('text')
         offer.seconds = seconds
         offer.consent = consent

--- a/offers.py
+++ b/offers.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+#
+# -*- coding: utf-8 -*-
+# vim: set ts=4 sw=4 et sts=4 ai:
+
+"""Module for viewing the offers."""
+
+import config
+config.setup()
+
+from google.appengine.api import users
+from google.appengine.ext import webapp
+
+from aeoid import users as openid_users
+
+import datetime
+import models
+import offer_lists
+
+from utils.render import render as r
+
+
+class Next(webapp.RequestHandler):
+    """Figure out the next offer, then redirect to it."""
+    def get(self):
+        self.redirect(offer_lists.get_next_event().get_url())
+
+
+class Offer(webapp.RequestHandler):
+    """Handler for display a single offer."""
+
+    def get(self, key=None):
+        # We are using locals which confuses pylint.
+        # pylint: disable-msg=W0612
+        if not key:
+            key = self.request.get('id')
+
+        key = long(key)
+        offer = models.Offer.get_by_id(key)
+
+        current_user = openid_users.get_current_user()
+        response, guests = offer_lists.get_event_responses(event, current_user)
+
+        self.response.headers['Content-Type'] = 'text/html'
+        self.response.out.write(r(
+            'templates/offer.html', locals()))
+
+
+class Offers(webapp.RequestHandler):
+    """Handler for display a table of offers."""
+
+    template = "templates/offers.html"
+    published_only = False
+
+    def get(self, year=None, month=None, day=None):
+        # We are using locals which confuses pylint.
+        # pylint: disable-msg=W0613,W0612
+        now = datetime.datetime.now()
+
+        if users.is_current_user_admin():
+            published_only = False
+        else:
+            published_only = True
+
+        current_user = openid_users.get_current_user()
+
+        offers_lists = event_lists.get_event_lists(
+                published_only=published_only, user=current_user)
+
+        next_offer = event_lists.get_next_event()
+
+        self.response.headers['Content-Type'] = 'text/html'
+        self.response.out.write(r(
+            self.template, locals()))

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -185,3 +185,29 @@ img, div, a, input {
   vertical-align: top;
   overflow-y: auto;
 }
+
+.hint {
+  display: inline;
+  font-size: smaller;
+}
+
+form li {
+  margin-top: 1em;
+}
+
+form li label {
+  vertical-align: top;
+}
+
+#talkOfferForm {
+  width: 600px;
+}
+
+.evenrow {
+  background-color: grey
+}
+
+.oddrow {
+  background-color: white
+}
+

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -42,8 +42,13 @@
   margin: 0;
 }
 
-#attend:hover {
+#attend:hover, #speak:hover {
   cursor: pointer;
+}
+
+#speak a:link, #speak a:visited {
+    color: #ffffff;
+    text-decoration: none;
 }
 
 #header {

--- a/templates/content-base.html
+++ b/templates/content-base.html
@@ -50,7 +50,8 @@ This page is based on the front page, but stripped down to have space to add con
                   <span class=minor> An event or SLUG as a whole </span>
                   </a>
                 </td>
-                <td id=speak class="box hover" onclick="location.href='mailto:activities@slug.org.au&subject=Talk%20suggestion'">
+                <td id=speak class="box hover">
+                  <a href="/
                   <h2> Give a talk </h2>
                   <span class=minor> Educate your fellows </span>
                 </a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -90,13 +90,6 @@ vim: set ts=2 sw=2 et sts=2 ai:
 {% endblock %}
 
 {% block script %}
-<script type="text/javascript">
-  //Turn links into buttons
-  $(function () {
-    $('#spoak a').button();
-  });
-
-</script>
 
 <script type="text/javascript">
   function handle_response() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -57,10 +57,11 @@ vim: set ts=2 sw=2 et sts=2 ai:
                   <span class=minor> An event or SLUG as a whole </span>
                   </a>
                 </td>
-                <td id=speak class="box hover" onclick="location.href='mailto:activities@slug.org.au&subject=Talk%20suggestion'">
-                  <h2> Give a talk </h2>
-                  <span class=minor> Educate your fellows </span>
-                </a>
+                <td id=speak class="box hover">
+                  <a href="/offer/add">
+                    <h2> Give a talk </h2>
+                    <span class=minor> Educate your fellows </span>
+                  </a>
                 </td>
               <tr>
             </table>
@@ -89,6 +90,14 @@ vim: set ts=2 sw=2 et sts=2 ai:
 {% endblock %}
 
 {% block script %}
+<script type="text/javascript">
+  //Turn links into buttons
+  $(function () {
+    $('#spoak a').button();
+  });
+
+</script>
+
 <script type="text/javascript">
   function handle_response() {
     event.preventDefault();

--- a/templates/offertalk.html
+++ b/templates/offertalk.html
@@ -8,20 +8,38 @@ vim: set ts=2 sw=2 et sts=2 ai:
 {% endblock %}
 {% block body %}
 
-<form id="talkOfferForm" class="clearfix" action="/offer/{{offer.key.id}}/edit"
+<form id="talkOfferForm" class="box clearfix" action="/offer/{{offer.key.id}}/edit"
     method="post">
   <ul class="eventData">
-    <li><label for="name">Talk Summary:</label>
-      <input type="text" name="name" value="{{offer.name}}"/></li>
-    <li><label for="text">Talk Details:</label>
+
+    <li class="evenRow"><label for="displayname">Your Name</label>
+    <input type="text" name="displayname" value="{{offer.displayname|default:user.nickname}}"/>
+      <div class="hint">This name will be used on meeting invitations and when
+      announcing your talk at the event</div></li>
+
+    <li class="oddRow"><label for="contactinfo">Contact Details</label>
+    <input type="text" name="contactinfo" value="{{offer.contactinfo|default:user.email}}"/>
+      <div class="hint">We'll follow up at this address to confirm your talk.
+        Your address will not be shared, and you will not be contacting for
+        anything other than confirming your offer.</div>
+    </li>
+
+    <li class="evenRow"><label for="name">Talk Title:</label>
+    <input type="text" name="name" value="{{offer.name}}"/>
+    <div class="hint"></li>
+
+    <li class="oddRow"><label for="text">Talk Details:</label>
       <textarea class="offerText" rows=5 cols=40 name="text">{{offer.text}}</textarea>
-    <li><label for="minutes">Talk length (in minutes)</label>
-      <input type="text" name="minutes" value="{{ offer.minutes  }}" /></li>
-    <li><label for="consent">I give consent for my talk to be recorded, and the
-      resulting video distributed under a <a
+
+    <li class="evenRow"><label for="minutes">Talk length</label>
+      <input type="text" name="minutes" value="{{ offer.minutes  }}" /> <div
+        class="hint">in minutes. As a guide, 5 minutes for a lightning talk, 35
+        for a long talk.</div></li>
+
+    <li class="oddRow"><label for="consent">I give consent for my talk to be recorded, and the
+      resulting video and audio distributed under a <a
         href="http://creativecommons.org/licenses/by-sa/3.0/au/deed.en">CC-BY-SA</a>
-      license</label>
-    <li><input type="checkbox"></li>
+      license</label> <input id="consent" type="checkbox"></li>
     <li><input type="submit"/></li>
   </ul>
 </form>


### PR DESCRIPTION
Remove offers from handler-admin, as it's not actually used there.
Tweaks to make the "speak" button work more reliably without js.
Force a login before allowing the user to make an offer, to make sure we can track the offer.
